### PR TITLE
Changed page searching method

### DIFF
--- a/scrape.rb
+++ b/scrape.rb
@@ -30,17 +30,20 @@ scraper.get(ADDRESS) do |search_page|
   # Submits form and stores results
   results_page = form.submit
 
-  # Creates an array for all the p tags with class result-info
-  raw_results = results_page.search('p.result-info')
+  # Creates an array for all the elements with class result-info (only p-tags)
+  raw_results = results_page.bases_with(class: 'result-info')
 
   # Parse each p tag for name and url
   raw_results.each do |result|
     # Finds the first a tag within the p tag
-    link = result.css('a')[0]
+    link = result.links[0]
     # Extracts the display text from the a tag
-    name = link.text.strip.to_s
+    name = link.text
     # Concatenates to provide the full url address
-    url = BASE_URL + link.attributes["href"].value
+    url = BASE_URL + link.uri
+
+    # Click the link and go to a new page
+    new_page = link.click
 
     # Checks to make sure the name has not already been stored to remove duplicate listings
     if !(name_dupe.include? name)


### PR DESCRIPTION
So the previous method, `results_page.search('p.result-info')`, gets at the [search method of the underlying parsing engine](http://docs.seattlerb.org/mechanize/Mechanize/Page.html#method-i-search) so it returns really generic objects that don't end up being super useful. I changed this to use a friendlier search method that we can get actual `Link` objects from later on, which makes everything easier.

I wasn't able to test this with the actual CSV output, since I don't have anything other than stock macOS ruby (which is crazy old) so it doesn't support the CSV package. Anyways, hope this helps! :)